### PR TITLE
Allow disabling of specific warnings via `-disable-warning:`

### DIFF
--- a/src/build_settings.cpp
+++ b/src/build_settings.cpp
@@ -444,6 +444,19 @@ enum IntegerDivisionByZeroKind : u8 {
 	IntegerDivisionByZero_AllBits,
 };
 
+struct NamedWarningString {
+	NamedWarning kind;
+	String       name;
+};
+
+enum NamedWarning : u32;
+
+NamedWarningString named_warning_name_map[] = {
+	{ NamedWarning_None, str_lit("") },
+	{ NamedWarning_ForeignProcRedecl, str_lit("foreign-proc-redecl") },
+};
+
+
 // This stores the information for the specify architecture of this build
 struct BuildContext {
 	// Constants
@@ -534,6 +547,7 @@ struct BuildContext {
 	bool   strict_style;
 
 	bool   ignore_warnings;
+	PtrSet< usize> disabled_warnings;
 	bool   warnings_as_errors;
 	bool   hide_error_line;
 	bool   terse_errors;
@@ -630,6 +644,9 @@ gb_internal bool global_warnings_as_errors(void) {
 }
 gb_internal bool global_ignore_warnings(void) {
 	return build_context.ignore_warnings;
+}
+gb_internal bool global_warning_is_ignored(NamedWarning warning) {
+	return global_ignore_warnings() || (warning != NamedWarning_None && ptr_set_exists(&build_context.disabled_warnings, (usize)warning));
 }
 
 gb_internal isize MAX_ERROR_COLLECTOR_COUNT(void) {

--- a/src/check_decl.cpp
+++ b/src/check_decl.cpp
@@ -1150,10 +1150,7 @@ gb_internal void check_foreign_procedure(CheckerContext *ctx, Entity *e, DeclInf
 		Type *other_type = base_type(f->type);
 		if (is_type_proc(this_type) && is_type_proc(other_type)) {
 			if (!are_signatures_similar_enough(this_type, other_type)) {
-				error(d->proc_lit,
-				      "Redeclaration of foreign procedure '%.*s' with different type signatures\n"
-				      "\tat %s",
-				      LIT(name), token_pos_to_string(pos));
+				warning_named(NamedWarning_ForeignProcRedecl, d->proc_lit, LIT(name), token_pos_to_string(pos));
 			}
 		} else if (!signature_parameter_similar_enough(this_type, other_type)) {
 			error(d->proc_lit,

--- a/src/llvm_backend_utility.cpp
+++ b/src/llvm_backend_utility.cpp
@@ -2897,7 +2897,7 @@ gb_internal void lb_do_para_poly_diagnostics(lbGenerator *gen) {
 
 		f64 average = cast(f64)code_size / cast(f64)gb_max(count, 1);
 
-		gb_printf("%23td | %19d | %25.2f | %.*s\n", code_size, count, average, LIT(name));
+		gb_printf("%23td | %19td | %25.2f | %.*s\n", code_size, count, average, LIT(name));
 		if (max_count-- <= 0) {
 			break;
 		}
@@ -2930,7 +2930,7 @@ gb_internal void lb_do_para_poly_diagnostics(lbGenerator *gen) {
 
 		f64 average = cast(f64)code_size / cast(f64)gb_max(count, 1);
 
-		gb_printf("%19d | %23td | %25.2f | %.*s\n", count, code_size, average, LIT(name));
+		gb_printf("%19td | %23td | %25.2f | %.*s\n", count, code_size, average, LIT(name));
 		if (max_count-- <= 0) {
 			break;
 		}

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -561,6 +561,24 @@ gb_internal void warning(Ast *node, char const *fmt, ...) {
 	va_end(va);
 }
 
+gb_internal void warning_named(NamedWarning warning, Ast *node, ...) {
+	GB_ASSERT(warning != NamedWarning_None);
+
+	auto* fmt = (const char*)named_warning_texts[warning].text;
+
+	Token token = {};
+	TokenPos end_pos = {};
+	if (node != nullptr) {
+		token = ast_token(node);
+		end_pos = ast_end_pos(node);
+	}
+
+	va_list va;
+	va_start(va, node);
+	warning_va(token.pos, end_pos, fmt, va, warning);
+	va_end(va);
+}
+
 gb_internal void syntax_error(Ast *node, char const *fmt, ...) {
 	Token token = {};
 	TokenPos end_pos = {};

--- a/src/ptr_set.cpp
+++ b/src/ptr_set.cpp
@@ -16,7 +16,7 @@ template <typename T> gb_internal bool ptr_set_exists (PtrSet<T> *s, T ptr);
 template <typename T> gb_internal void ptr_set_remove (PtrSet<T> *s, T ptr);
 template <typename T> gb_internal void ptr_set_clear  (PtrSet<T> *s);
 
-#define FOR_PTR_SET(element, set_) for (auto *it = &(set_).keys[0], element = it ? *it : nullptr; (set_).keys != nullptr && it < &(set_).keys[(set_).capacity]; it++) if (element = *it, (*it != nullptr && *it != cast(void *)~(uintptr)(0ull)))
+#define FOR_PTR_SET(element, set_) for (auto *it = &(set_).keys[0], element = it ? *it : 0; (set_).keys != nullptr && it < &(set_).keys[(set_).capacity]; it++) if (element = *it, (*it != 0 && (uintptr)*it != ~(uintptr)(0ull)))
 
 gb_internal gbAllocator ptr_set_allocator(void) {
 	return heap_allocator();


### PR DESCRIPTION
Lays basic groundwork for named warnings.

Downgrades "Redeclaration of foreign procedure" from error to warning and makes it a named warning.

This is useful as it permits the user to opt-out of getting stuck behind a compiler error whenever a minor collision of type signature between procedures from the bundled collection libraries and user-provided ones.